### PR TITLE
fix: INF-186: Run image as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,6 @@ COPY graph.db3 .
 COPY templates/ templates/
 COPY target/release/server .
 
+USER 1000
+
 CMD ["./server"]


### PR DESCRIPTION
In order to adhere to our kubernetes linter and follow best practices: https://github.com/stackrox/kube-linter/blob/main/docs/generated/checks.md#run-as-non-root